### PR TITLE
Improve Heroku deployment for automatic n8n updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,15 @@
-FROM n8nio/n8n:latest
+# syntax=docker/dockerfile:1
 
+ARG N8N_VERSION=latest
+FROM n8nio/n8n:${N8N_VERSION}
+
+# Run as root to allow runtime updates of the n8n CLI when requested.
 USER root
 
-WORKDIR /home/node/packages/cli
-ENTRYPOINT []
+# Replace the entrypoint with a Heroku-friendly bootstrap script that
+# prepares the database configuration and optionally keeps n8n updated.
+COPY entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
 
-COPY ./entrypoint.sh /
-RUN chmod +x /entrypoint.sh
-CMD ["/entrypoint.sh"]
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["n8n", "start"]

--- a/README.md
+++ b/README.md
@@ -6,8 +6,18 @@
 
 This is a [Heroku](https://heroku.com/)-focused container implementation of [n8n](https://n8n.io/).
 
-Use the **Deploy to Heroku** button above to launch n8n on Heroku. When deploying, make sure to check all configuration options and adjust them to your needs. It's especially important to set `N8N_ENCRYPTION_KEY` to a random secure value. 
+Use the **Deploy to Heroku** button above to launch n8n on Heroku. When deploying, make sure to check all configuration options
+and adjust them to your needs. It's especially important to set `N8N_ENCRYPTION_KEY` to a random secure value.
 
 Refer to the [Heroku n8n tutorial](https://docs.n8n.io/hosting/server-setups/heroku/) for more information.
 
 If you have questions after trying the tutorials, check out the [forums](https://community.n8n.io/).
+
+## Automatic n8n version management
+
+This container keeps the n8n CLI up to date without requiring code changes:
+
+- Set the `N8N_VERSION` config var to pin a specific n8n release. The default value (`latest`) resolves to the newest stable version on each deploy or dyno restart.
+- Automatic upgrades can be disabled by setting `N8N_AUTO_UPDATE=false` if you prefer to manage updates manually.
+
+During startup the entrypoint script compares the installed version with the desired one and installs upgrades when required, ensuring that only n8n itself changes while the rest of the environment remains stable.

--- a/app.json
+++ b/app.json
@@ -1,43 +1,51 @@
 {
-    "name": "n8n",
-    "description": "deploy n8n to heroku without any hassle",
-    "keywords": [
-      "n8n",
-      "node",
-      "automation"
-    ],
-    "website": "https://n8n.io",
-    "repository": "https://github.com/kuromi04/n8n-heroku2025.git",
-    "logo": "https://raw.githubusercontent.com/n8n-io/n8n-heroku/main/n8n_logo.png",
-    "success_url": "/",
-    "stack": "container",
-    "env": {
-      "GENERIC_TIMEZONE": {
-        "description": "Time Zone to use with Heroku. You can find the name of your timezone for example here: https://momentjs.com/timezone/.",
-        "value": "Europe/Berlin"
-      },
-      "N8N_ENCRYPTION_KEY": {
-        "description": "Set the n8n encryption key to a static value to avoid Heroku overriding it (causing authentication to fail).",
-        "value": "change-me-to-something-else"
-      },
-      "WEBHOOK_URL": {
-        "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",
-        "value": "https://<appname>.herokuapp.com"
-      },
-      "DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED": {
-        "description": "SSL is required to connect to Postgres on Heroku",
-        "value": "false"
+  "name": "n8n",
+  "description": "Deploy n8n to Heroku without any hassle",
+  "keywords": [
+    "n8n",
+    "node",
+    "automation"
+  ],
+  "website": "https://n8n.io",
+  "repository": "https://github.com/kuromi04/n8n-heroku2025.git",
+  "logo": "https://raw.githubusercontent.com/n8n-io/n8n-heroku/main/n8n_logo.png",
+  "success_url": "/",
+  "stack": "container",
+  "env": {
+    "GENERIC_TIMEZONE": {
+      "description": "Time Zone to use with Heroku. You can find the name of your timezone for example here: https://momentjs.com/timezone/.",
+      "value": "Europe/Berlin"
+    },
+    "N8N_ENCRYPTION_KEY": {
+      "description": "Set the n8n encryption key to a static value to avoid Heroku overriding it (causing authentication to fail).",
+      "value": "change-me-to-something-else"
+    },
+    "WEBHOOK_URL": {
+      "description": "Replace <appname> with your Heroku application name. This will ensure the correct webhook URLs are being shown in n8n.",
+      "value": "https://<appname>.herokuapp.com"
+    },
+    "DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED": {
+      "description": "SSL is required to connect to Postgres on Heroku",
+      "value": "false"
+    },
+    "N8N_VERSION": {
+      "description": "Desired n8n release (for example 1.42.0). Leave as 'latest' to automatically install the newest stable version during deploy.",
+      "value": "latest"
+    },
+    "N8N_AUTO_UPDATE": {
+      "description": "Set to 'false' to disable automatic updates when the running version differs from N8N_VERSION.",
+      "value": "true"
+    }
+  },
+  "addons": [
+    {
+      "plan": "heroku-postgresql",
+      "options": {
+        "version": "15"
       }
     },
-    "addons": [
-      {
-        "plan": "heroku-postgresql",
-        "options": {
-          "version": "15"
-        }
-      },
-      {
-        "plan": "papertrail:choklad"
-      }
-    ]
-  }
+    {
+      "plan": "papertrail:choklad"
+    }
+  ]
+}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,26 +1,137 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -euo pipefail
 
-# check if port variable is set or go with default
-if [ -z ${PORT+x} ]; then echo "PORT variable not defined, leaving N8N to default port."; else export N8N_PORT="$PORT"; echo "N8N will start on '$PORT'"; fi
+DEFAULT_CMD=("n8n" "start")
 
-# regex function
-parse_url() {
-  eval $(echo "$1" | sed -e "s#^\(\(.*\)://\)\?\(\([^:@]*\)\(:\(.*\)\)\?@\)\?\([^/?]*\)\(/\(.*\)\)\?#${PREFIX:-URL_}SCHEME='\2' ${PREFIX:-URL_}USER='\4' ${PREFIX:-URL_}PASSWORD='\6' ${PREFIX:-URL_}HOSTPORT='\7' ${PREFIX:-URL_}DATABASE='\9'#")
+log() {
+  local timestamp
+  timestamp="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+  printf '[%s] %s\n' "$timestamp" "$*"
 }
 
-# prefix variables to avoid conflicts and run parse url function on arg url
-PREFIX="N8N_DB_" parse_url "$DATABASE_URL"
-echo "$N8N_DB_SCHEME://$N8N_DB_USER:$N8N_DB_PASSWORD@$N8N_DB_HOSTPORT/$N8N_DB_DATABASE"
-# Separate host and port    
-N8N_DB_HOST="$(echo $N8N_DB_HOSTPORT | sed -e 's,:.*,,g')"
-N8N_DB_PORT="$(echo $N8N_DB_HOSTPORT | sed -e 's,^.*:,:,g' -e 's,.*:\([0-9]*\).*,\1,g' -e 's,[^0-9],,g')"
+configure_port() {
+  if [ -n "${PORT:-}" ]; then
+    export N8N_PORT="$PORT"
+    log "Using Heroku PORT=${PORT} for N8N_PORT."
+  else
+    log "PORT is not defined; using the default n8n port."
+  fi
+}
 
-export DB_TYPE=postgresdb
-export DB_POSTGRESDB_HOST=$N8N_DB_HOST
-export DB_POSTGRESDB_PORT=$N8N_DB_PORT
-export DB_POSTGRESDB_DATABASE=$N8N_DB_DATABASE
-export DB_POSTGRESDB_USER=$N8N_DB_USER
-export DB_POSTGRESDB_PASSWORD=$N8N_DB_PASSWORD
+configure_database() {
+  if [ -z "${DATABASE_URL:-}" ]; then
+    log "DATABASE_URL not provided; skipping database configuration."
+    return
+  fi
 
-# kickstart nodemation
-n8n
+  local db_values
+  IFS=$'\n' read -r -d '' -a db_values < <(node <<'NODE' && printf '\0'
+const urlValue = process.env.DATABASE_URL;
+try {
+  const parsed = new URL(urlValue);
+  if (!/^postgres/i.test(parsed.protocol)) {
+    console.log('');
+    console.log('');
+    console.log('');
+    console.log('');
+    console.log('');
+    process.exit(0);
+  }
+
+  const withoutLeadingSlash = parsed.pathname ? parsed.pathname.replace(/^\//, '') : '';
+  console.log(parsed.hostname ?? '');
+  console.log(parsed.port || '5432');
+  console.log(parsed.username || '');
+  console.log(parsed.password || '');
+  console.log(withoutLeadingSlash);
+} catch (error) {
+  console.error(error.message);
+  process.exit(1);
+}
+NODE
+  ) || {
+    log "Failed to parse DATABASE_URL; aborting.";
+    exit 1
+  }
+
+  # If the protocol was not Postgres we bail out silently.
+  if [ "${#db_values[@]}" -eq 0 ] || [ -z "${db_values[0]}${db_values[2]}${db_values[4]}" ]; then
+    log "DATABASE_URL is not a Postgres connection string; skipping database configuration."
+    return
+  fi
+
+  export DB_TYPE=postgresdb
+  export DB_POSTGRESDB_HOST="${db_values[0]}"
+  export DB_POSTGRESDB_PORT="${db_values[1]}"
+  export DB_POSTGRESDB_USER="${db_values[2]}"
+  export DB_POSTGRESDB_PASSWORD="${db_values[3]}"
+  export DB_POSTGRESDB_DATABASE="${db_values[4]}"
+
+  log "Configured Postgres database ${DB_POSTGRESDB_DATABASE} on ${DB_POSTGRESDB_HOST}:${DB_POSTGRESDB_PORT}."
+}
+
+current_n8n_version() {
+  n8n --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true
+}
+
+desired_n8n_version() {
+  local requested
+  requested="${N8N_VERSION:-latest}"
+  if [ "$requested" = "latest" ]; then
+    npm view n8n version 2>/dev/null || true
+  else
+    printf '%s\n' "$requested"
+  fi
+}
+
+maybe_update_n8n() {
+  local auto_update
+  auto_update="${N8N_AUTO_UPDATE:-true}"
+
+  if [ "$auto_update" != "true" ]; then
+    log "Skipping automatic n8n updates (N8N_AUTO_UPDATE=${auto_update})."
+    return
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    log "npm is not available; cannot update n8n automatically."
+    return
+  fi
+
+  local target_version
+  target_version="$(desired_n8n_version)"
+  if [ -z "$target_version" ]; then
+    log "Unable to determine the desired n8n version; skipping update."
+    return
+  fi
+
+  local installed_version
+  installed_version="$(current_n8n_version)"
+
+  if [ "$installed_version" = "$target_version" ]; then
+    log "n8n ${installed_version} is already installed."
+    return
+  fi
+
+  log "Updating n8n from ${installed_version:-unknown} to ${target_version}."
+  if npm install -g "n8n@${target_version}" --loglevel=error --no-fund; then
+    log "Successfully updated n8n to version ${target_version}."
+  else
+    log "Failed to update n8n; continuing with version ${installed_version:-unknown}."
+  fi
+}
+
+main() {
+  if [ "$#" -eq 0 ]; then
+    set -- "${DEFAULT_CMD[@]}"
+  fi
+
+  configure_port
+  configure_database
+  maybe_update_n8n
+
+  log "Starting n8n with command: $*"
+  exec "$@"
+}
+
+main "$@"

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,8 +1,12 @@
 setup:
-    addons:
-      - plan: heroku-postgresql
-        as: DATABASE
-
+  addons:
+    - plan: heroku-postgresql
+      as: DATABASE
 build:
-    docker:
-        web: Dockerfile
+  docker:
+    web: Dockerfile
+release:
+  command:
+    - n8n migrate:database
+run:
+  web: n8n start


### PR DESCRIPTION
## Summary
- allow specifying the desired n8n release at build time and replace the entrypoint with a Heroku-aware bootstrap script that can auto-upgrade n8n
- expose new configuration options in app.json and document the automatic version management behaviour
- fix the Heroku manifest to include database migrations during release

## Testing
- Not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_b_68ec7ff591748327b643ecb0c997e4bb